### PR TITLE
lava_command: add enter/exit hooks to call host-side tool

### DIFF
--- a/lava_dispatcher/config.py
+++ b/lava_dispatcher/config.py
@@ -29,6 +29,11 @@ from configglue import parser, schema
 
 
 class DeviceSchema(schema.Schema):
+
+    # Host-side hook for lava_command_run
+    host_hook_enter_command = schema.StringOption()
+    host_hook_exit_command = schema.StringOption()
+
     master_testboot_dir = schema.StringOption()
     master_testboot_label = schema.StringOption()
     master_testrootfs_dir = schema.StringOption()


### PR DESCRIPTION
This is used to generate measurements by interacting with devices that are
not reachable as a node. Each **device.conf ** file can define a host command or
script used when entering a lava_command_run and leaving a lava_command_run.

host_hook_enter_command = ...(phrase to pass to host)
host_hook_exit_command = ...

Hook calling abi with {enter_hook} as the phrase from the config file above:

ENTRER: arg0 = {enter_hook}  arg1 = logdir/{enter_hook}.dat &
EXIT:   arg0 = {exit_hook}   arg1 = logdir/{enter_hook}.dat &

A test_case_id is created to show the output of the hook as a
'measurement' field (stdout of exit hook)

any file found in the logdir will be attached, starting with
stdout.log. If a {file}.minetype is found, its content is used
as 'mime_type' for the attached file (as with lava_shell_test)

See an example here: http://lava-baylibre.local:10080/dashboard/streams/anonymous/powerci/bundles/e143f574655be2fe2f03dd94c6e46f89e84966e2/466271e4-889d-445d-b884-d7e6052a6d3b/

Signed-off-by: Marc Titinger <mtitinger@baylibre.com