### PR TITLE
Remove device check from pyocd deploy

### DIFF
--- a/lava_dispatcher/pipeline/actions/deploy/image.py
+++ b/lava_dispatcher/pipeline/actions/deploy/image.py
@@ -142,8 +142,6 @@ class DeployMonitoredPyOCD(Deployment):
         This is *not* the same as validation of the action
         which can use instance data.
         """
-        if device['device_type'] not in ['nrf52-nitrogen', 'nxp-k64f']:
-            return False
         if parameters['to'] != 'tmpfs':
             return False
         # lookup if the job parameters match the available device methods


### PR DESCRIPTION
Other device-types can benefit from pyocd deploy module so
remove the static check for device-type name matching