### PR TITLE
Add guestfs target mount point

### DIFF
--- a/lava_dispatcher/actions/deploy/apply_overlay.py
+++ b/lava_dispatcher/actions/deploy/apply_overlay.py
@@ -82,9 +82,11 @@ class ApplyOverlayGuest(Action):
         guest_dir = self.mkdtemp()
         guest_file = os.path.join(guest_dir, self.guest_filename)
         self.set_namespace_data(action=self.name, label='guest', key='filename', value=guest_file)
+        lava_test_results_dir = self.get_namespace_data(action='test', label='results', key='lava_test_results_dir')
         blkid = prepare_guestfs(
             guest_file, overlay_file,
-            self.job.device['actions']['deploy']['methods']['image']['parameters']['guest']['size'])
+            self.job.device['actions']['deploy']['methods']['image']['parameters']['guest']['size'],
+            lava_test_results_dir)
         self.results = {'success': blkid}
         self.set_namespace_data(action=self.name, label='guest', key='UUID', value=blkid)
         return connection

--- a/lava_dispatcher/utils/filesystem.py
+++ b/lava_dispatcher/utils/filesystem.py
@@ -116,9 +116,9 @@ def write_bootscript(commands, filename):
 
 
 @replace_exception(RuntimeError, JobError)
-def prepare_guestfs(output, overlay, size):
+def prepare_guestfs(output, overlay, size, target_mountpoint=""):
     """
-    Applies the overlay, offset by one directory.
+    Applies the overlay, offset by the target directory.
     This allows the booted device to mount at the
     original lava directory and retain the same path
     as if the overlay was unpacked directly into the
@@ -126,6 +126,7 @@ def prepare_guestfs(output, overlay, size):
     :param output: filename of the temporary device
     :param overlay: tarball of the lava test shell overlay.
     :param size: size of the filesystem in Mb
+    :param target_mountpoint: path to the mount point on the host
     :return blkid of the guest device
     """
     guest = guestfs.GuestFS(python_return_dict=True)
@@ -146,9 +147,10 @@ def prepare_guestfs(output, overlay, size):
     guest_dir = mkdtemp()
     guest_tar = os.path.join(guest_dir, 'guest.tar')
     root_tar = tarfile.open(guest_tar, 'w')
-    for topdir in os.listdir(tar_output):
-        for dirname in os.listdir(os.path.join(tar_output, topdir)):
-            root_tar.add(os.path.join(tar_output, topdir, dirname), arcname=dirname)
+    target_mountpoint = target_mountpoint.lstrip("/")
+    topdir = os.path.join(tar_output, target_mountpoint)
+    for dirname in os.listdir(topdir):
+        root_tar.add(os.path.join(tar_output, topdir, dirname), arcname=dirname)
     root_tar.close()
     guest.tar_in(guest_tar, '/')
     os.unlink(guest_tar)


### PR DESCRIPTION
Allow to specify any path in `lava_test_results_dir` for deployments.
This is useful for testing OS with read-only '/' in Qemu.

Originally guest image for Qemu is mounted to target mount point but in the same
time path inside the image skip only 1 directory in hierarchy doubling
the rest of the path in Qemu VM, for instance:
`/var/lib/lava-5/lib/lava-5/bin/...` instead of `/var/lib/lava-5/bin/...`.
This behavior causes the issues in `lava-test-shell` test:
 lava-test: # lava-test: # sh: 9: /var/lib/lava-5/bin/lava-test-runner: not found

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>